### PR TITLE
Now accepts one or more --tree options. These switch off the default

### DIFF
--- a/bin/pod_server
+++ b/bin/pod_server
@@ -10,6 +10,8 @@ my %opts = (
 );
 
 my $C = \%Pod::Server::CONFIG;
+my $trees = [];
+$C->{tree} = $trees;
 
 GetOptions(
   $C,
@@ -39,6 +41,7 @@ GetOptions(
   "title|t=s",
   "port|p=i",
   "help|h",
+  "tree=s"
 );
 
 if ($C->{help}) {
@@ -83,6 +86,9 @@ Options:
   -v, --vim BOOLEAN                  Syntax highlight source code with vim?
                                      Set to "0" to disable.
                                      (defaults to '$C->{vim}')
+
+      --tree STRING                  Direcory tree to search. Can occur
+                                     several times. eg --tree dir1 --tree dir2.
 
   -h, --help                         This help message
 

--- a/lib/Pod/Server.pm
+++ b/lib/Pod/Server.pm
@@ -93,7 +93,16 @@ sub scan {
       print "\n";
     },
   }));
-  my $survey = $search->survey;
+
+  my $survey;
+  if (scalar(@{$CONFIG{tree}})) {
+    $search->inc(0);
+    $survey = $search->survey(@{$CONFIG{tree}});
+  }
+  else {
+    $survey = $search->survey;
+  }
+
   for (keys %$survey) {
     my $key = $_;
     $key =~ s/::/\//g;


### PR DESCRIPTION
searching for modules and specify which directory trees should be search
for pod.

Does not affect the list of executables, only the list of modules.
